### PR TITLE
add support for chat history for bedrock interface

### DIFF
--- a/middleware/app.py
+++ b/middleware/app.py
@@ -9,14 +9,90 @@ import google_crc32c
 import zlib
 import boto3
 import re
+import os
+import uuid
+from sqlalchemy import create_engine, MetaData, Table, Column, String, Text, inspect
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.sql import select, insert, update
 
 app = FastAPI()
 
-# Since we're in the same container, we can use localhost
 LITELLM_ENDPOINT = "http://localhost:4000"
 LITELLM_CHAT = f"{LITELLM_ENDPOINT}/v1/chat/completions"
 
 bedrock_client = boto3.client("bedrock-agent")
+
+db_engine = None
+metadata = MetaData()
+chat_sessions = None
+
+
+def setup_database():
+    try:
+        database_url = os.environ.get("DATABASE_MIDDLEWARE_URL")
+        if not database_url:
+            raise ValueError("DATABASE_MIDDLEWARE_URL environment variable not set")
+
+        engine = create_engine(database_url)
+        metadata_obj = MetaData()
+
+        inspector = inspect(engine)
+        if "chat_sessions" not in inspector.get_table_names():
+            chat_sessions_table = Table(
+                "chat_sessions",
+                metadata_obj,
+                Column("session_id", String, primary_key=True),
+                Column("chat_history", Text),
+            )
+            metadata_obj.create_all(engine)
+            print("Created chat_sessions table")
+        else:
+            chat_sessions_table = Table(
+                "chat_sessions", metadata_obj, autoload_with=engine
+            )
+            print("chat_sessions table already exists")
+
+        return engine, chat_sessions_table
+    except SQLAlchemyError as e:
+        print(f"Database setup error: {str(e)}")
+        raise
+
+
+@app.on_event("startup")
+async def startup_event():
+    global db_engine, chat_sessions
+    db_engine, chat_sessions = setup_database()
+
+
+def get_chat_history(session_id: str) -> Optional[List[Dict[str, str]]]:
+    with db_engine.connect() as conn:
+        stmt = select(chat_sessions.c.chat_history).where(
+            chat_sessions.c.session_id == session_id
+        )
+        result = conn.execute(stmt).fetchone()
+        if result and result[0]:
+            return json.loads(result[0])
+    return None
+
+
+def create_chat_history(session_id: str, chat_history: List[Dict[str, str]]):
+    with db_engine.connect() as conn:
+        stmt = insert(chat_sessions).values(
+            session_id=session_id, chat_history=json.dumps(chat_history)
+        )
+        conn.execute(stmt)
+        conn.commit()
+
+
+def update_chat_history(session_id: str, chat_history: List[Dict[str, str]]):
+    with db_engine.connect() as conn:
+        stmt = (
+            update(chat_sessions)
+            .where(chat_sessions.c.session_id == session_id)
+            .values(chat_history=json.dumps(chat_history))
+        )
+        conn.execute(stmt)
+        conn.commit()
 
 
 class CustomEventStream:
@@ -36,20 +112,17 @@ def create_event_message(payload, event_type_name):
     event_name_bytes = event_type_name.encode("utf-8")
     event_name_length = len(event_name_bytes)
 
-    # Build headers block
     headers_bytes = (
         struct.pack("B", header_name_length)
         + header_name
-        + b"\x07"  # string type
+        + b"\x07"
         + struct.pack(">H", event_name_length)
         + event_name_bytes
     )
 
     headers_length = len(headers_bytes)
     payload_length = len(payload)
-    total_length = (
-        payload_length + headers_length + 16
-    )  # 16 bytes = prelude(8) + message_crc(4) + prelude_crc(4)
+    total_length = payload_length + headers_length + 16
 
     prelude = struct.pack(">I", total_length) + struct.pack(">I", headers_length)
     prelude_crc = struct.pack(">I", zlib.crc32(prelude) & 0xFFFFFFFF)
@@ -64,21 +137,16 @@ def convert_messages_to_openai(
     bedrock_messages: List[Dict[str, Any]],
     system: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
-    """Convert Bedrock message format to OpenAI format."""
     openai_messages = []
 
-    # Add system message if present
     if system:
         system_text = " ".join(item.get("text", "") for item in system)
         if system_text:
             openai_messages.append({"role": "system", "content": system_text})
 
-    # Convert Bedrock messages to OpenAI format
     for msg in bedrock_messages:
         role = msg.get("role")
         content = ""
-
-        # Extract text from content array
         if "content" in msg:
             for content_item in msg["content"]:
                 if "text" in content_item:
@@ -92,56 +160,34 @@ def convert_messages_to_openai(
 async def convert_bedrock_to_openai(
     model_id: str, bedrock_request: Dict[str, Any], streaming: bool
 ) -> Dict[str, Any]:
-
     prompt_variables = bedrock_request.get("promptVariables", {})
     final_prompt_text = None
-    print(f"initial_model_id: {model_id}")
     if model_id.startswith("arn:aws:bedrock:"):
-        print(f"entered first if with model_id: {model_id}")
         prompt_id, prompt_version = parse_prompt_arn(model_id)
-        print(f"prompt_id: {prompt_id} prompt_version: {prompt_version}")
         if prompt_id:
-            print(f"prompt_id: {prompt_id}")
-            # Retrieve the prompt
             if prompt_version:
-                print(f"prompt_version: {prompt_version}")
                 prompt = bedrock_client.get_prompt(
                     promptIdentifier=prompt_id, promptVersion=prompt_version
                 )
             else:
                 prompt = bedrock_client.get_prompt(promptIdentifier=prompt_id)
 
-            print(f"prompt: {prompt}")
             variants = prompt.get("variants", [])
-            print(f"variants: {variants}")
             variant = variants[0]
-            print(f"variant: {variant}")
             template_text = variant["templateConfiguration"]["text"]["text"]
-            print(f"template_text: {template_text}")
-            print(f"prompt_variables: {prompt_variables}")
-            # Construct the prompt by replacing variables
 
             validate_prompt_variables(template_text, prompt_variables)
-
             final_prompt_text = construct_prompt_text_from_variables(
                 template_text, prompt_variables
             )
-            print(f"final_prompt_text: {final_prompt_text}")
             model_id = variant["modelId"]
-            print(f"prompt model_id: {model_id}")
 
-    """Convert Bedrock Converse API format to OpenAI format."""
     completion_params = {"model": model_id}
-    print(f"completion_params: {completion_params}")
 
-    print(f'bedrock_request.get("messages", []): {bedrock_request.get("messages", [])}')
-
-    # Convert messages
     if final_prompt_text:
         final_prompt_messages = [
             {"role": "user", "content": [{"text": final_prompt_text}]}
         ]
-        print(f"final_prompt_messages: {final_prompt_messages}")
         messages = convert_messages_to_openai(final_prompt_messages, [])
     else:
         messages = convert_messages_to_openai(
@@ -152,7 +198,6 @@ async def convert_bedrock_to_openai(
     if streaming:
         completion_params["stream"] = True
 
-    # Map inference configuration
     if "inferenceConfig" in bedrock_request:
         config = bedrock_request["inferenceConfig"]
         if "temperature" in config:
@@ -164,15 +209,19 @@ async def convert_bedrock_to_openai(
         if "topP" in config:
             completion_params["top_p"] = config["topP"]
 
-    # Add any additional model fields
     if "additionalModelRequestFields" in bedrock_request:
-        completion_params.update(bedrock_request["additionalModelRequestFields"])
+        # Exclude "session-id" from being added to completion_params
+        additional_fields = {
+            key: value
+            for key, value in bedrock_request["additionalModelRequestFields"].items()
+            if key != "session-id"
+        }
+        completion_params.update(additional_fields)
 
     return completion_params
 
 
 async def convert_openai_to_bedrock(openai_response: Dict[str, Any]) -> Dict[str, Any]:
-    """Convert OpenAI format to Bedrock Converse API format."""
     bedrock_response = {
         "output": {
             "message": {
@@ -189,7 +238,6 @@ async def convert_openai_to_bedrock(openai_response: Dict[str, Any]) -> Dict[str
         },
     }
 
-    # Add stop reason if present
     if "finish_reason" in openai_response["choices"][0]:
         stop_reason_map = {
             "stop": "end_turn",
@@ -204,114 +252,68 @@ async def convert_openai_to_bedrock(openai_response: Dict[str, Any]) -> Dict[str
 
 
 async def openai_stream_to_bedrock_chunks(openai_stream):
-    message_started = False
-    content_block_index = 0
-
     async for chunk in openai_stream:
-        print(f"chunk: {chunk}")
-        # chunk looks like:
-        # {
-        #   "id": "...",
-        #   "object": "chat.completion.chunk",
-        #   "created": 1681234567,
-        #   "choices": [
-        #       {
-        #         "delta": {"role": "assistant"} or {"content": "partial text"},
-        #         "index":0,
-        #         "finish_reason": null or "stop"
-        #       }
-        #    ]
-        # }
         delta = chunk.choices[0].delta
         finish_reason = chunk.choices[0].finish_reason
 
-        # When role=assistant appears, start message
-        if delta.role and not message_started:
-            # Just return the role payload
+        if delta.role:
             event_payload = json.dumps({"role": delta.role}).encode("utf-8")
             yield create_event_message(event_payload, "messageStart")
-            message_started = True
 
         if delta.content:
-            # Provide contentBlockDelta fields directly, not nested under "contentBlockDelta"
             event_payload = json.dumps(
                 {
-                    "contentBlockIndex": content_block_index,
+                    "contentBlockIndex": 0,
                     "delta": {"text": delta.content},
                 }
             ).encode("utf-8")
             yield create_event_message(event_payload, "contentBlockDelta")
 
         if finish_reason == "stop":
-            # Just the stopReason field at top-level
             event_payload = json.dumps({"stopReason": "end_turn"}).encode("utf-8")
             yield create_event_message(event_payload, "messageStop")
 
 
-# For some reason, fastapi takes escaped forward slashes (%2F) as being regular forward slashes, so needed to add a new route
-@app.post("/bedrock/model/{prompt_arn_prefix}/{prompt_id}/converse-stream")
-async def handle_bedrock_streaming_request_prompts(
-    prompt_arn_prefix: str, prompt_id: str, request: Request
-):
-    print(f"prompt_arn_prefix: {prompt_arn_prefix}")
-    print(f"prompt_id: {prompt_id}")
-    full_arn = prompt_arn_prefix + "/" + prompt_id
-    print(f"full_arn: {full_arn}")
-    result = await handle_bedrock_streaming_request(full_arn, request)
-    return result
+def parse_prompt_arn(arn: str):
+    if "prompt/" not in arn:
+        return None, None
+
+    after_prompt = arn.split("prompt/", 1)[1]
+
+    if ":" in after_prompt:
+        prompt_id, prompt_version = after_prompt.split(":", 1)
+        return prompt_id, prompt_version
+    else:
+        return after_prompt, None
 
 
-@app.post("/bedrock/model/{model_id}/converse-stream")
-async def handle_bedrock_streaming_request(model_id: str, request: Request):
-    try:
-        body = await request.json()
+def validate_prompt_variables(template_text: str, variables: Dict[str, Any]):
+    found_placeholders = re.findall(r"{{\s*(\w+)\s*}}", template_text)
+    placeholders_set = set(found_placeholders)
+    variables_set = set(variables.keys())
 
-        auth_header = request.headers.get("Authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            api_key = auth_header[len("Bearer ") :]
-        else:
-            print(f"Missing or invalid Authorization header")
-            return JSONResponse(
-                status_code=401,
-                content={"error": "Missing or invalid Authorization header"},
-            )
+    if placeholders_set != variables_set:
+        detail_message = {
+            "message": f"Prompt variable mismatch. Template placeholders: {placeholders_set}. Provided variables: {variables_set}."
+        }
+        raise HTTPException(status_code=400, detail=detail_message)
 
-        openai_params = await convert_bedrock_to_openai(model_id, body, True)
 
-        # Create the OpenAI client with the provided API key
-        client = AsyncOpenAI(api_key=api_key, base_url=LITELLM_ENDPOINT)
-
-        # Create the streaming completion
-        # Note: The exact method name/path (`client.chat.completions.create`) may vary depending on the library version.
-        stream = await client.chat.completions.create(**openai_params)
-
-        return StreamingResponse(
-            openai_stream_to_bedrock_chunks(stream),
-            media_type="application/vnd.amazon.eventstream",  # Changed media type
-        )
-    except HTTPException as he:
-        print(f"HTTPException: {he} detail: {he.detail}")
-        return JSONResponse(
-            status_code=400,
-            content=he.detail,
-        )
-    except Exception as e:
-        print(f"Exception: {e}")
-        return JSONResponse(status_code=500, content=f"Internal server error: {str(e)}")
+def construct_prompt_text_from_variables(template_text: str, variables: dict) -> str:
+    for var_name, var_value in variables.items():
+        value = var_value.get("text", "")
+        template_text = template_text.replace(f"{{{{{var_name}}}}}", value)
+    return template_text
 
 
 @app.get("/bedrock/health/liveliness")
 async def health_check():
-    print(f"reached health check")
-    """Health check endpoint."""
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{LITELLM_ENDPOINT}/health/liveliness", timeout=5.0
             )
-            print(f"health check status code: {response.status_code}")
             if response.status_code == 200:
-
                 return JSONResponse(
                     content={"status": "healthy", "litellm": "connected"}
                 )
@@ -326,111 +328,231 @@ async def health_check():
         )
 
 
-def parse_prompt_arn(arn: str):
-    # Example ARN formats:
-    # Without version: arn:aws:bedrock:us-west-2:235614385815:prompt/6LE1KDKISG
-    # With version: arn:aws:bedrock:us-west-2:235614385815:prompt/6LE1KDKISG:2
-    print(f"arn: {arn}")
-
-    # First, split on "prompt/" to isolate the prompt identifier and optional version
-    if "prompt/" not in arn:
-        print(f"returning none for parse_prompt_arn because prompt is not in {arn}")
-        return None, None
-
-    # after_prompt might look like "6LE1KDKISG" or "6LE1KDKISG:2"
-    after_prompt = arn.split("prompt/", 1)[1]
-    print(f"after_prompt: {after_prompt}")
-
-    # Now split after_prompt on ":" to see if we have a version
-    if ":" in after_prompt:
-        prompt_id, prompt_version = after_prompt.split(":", 1)
-        print(f"prompt_id: {prompt_id} prompt_version: {prompt_version}")
-        return prompt_id, prompt_version
+async def process_chat_request(
+    model_id: str, request: Request
+) -> (Dict[str, Any], str):
+    body = await request.json()
+    session_id = body.get("additionalModelRequestFields", {}).get("session-id", None)
+    print(f"session_id: {session_id}")
+    if session_id is not None:
+        chat_history = get_chat_history(session_id)
+        print(f"chat_history: {chat_history}")
+        if chat_history is None:
+            chat_history = []
+            create_chat_history(session_id, chat_history)
     else:
-        print(f"after_prompt: {after_prompt}")
-        return after_prompt, None
+        session_id = str(uuid.uuid4())
+        chat_history = []
+        create_chat_history(session_id, chat_history)
+
+    openai_format = await convert_bedrock_to_openai(model_id, body, False)
+    print(f"openai_format: {openai_format}")
+
+    # Append the last user message to chat_history
+    user_messages_this_round = [
+        m for m in openai_format["messages"] if m["role"] == "user"
+    ]
+    if user_messages_this_round:
+        chat_history.append(user_messages_this_round[-1])
+
+    print(f"chat_history: {chat_history}")
+
+    # If we have a session (existing or new), we want to pass the full history to the LLM
+    # Replace openai_format["messages"] with the full chat_history (which now includes the latest user message)
+    openai_format["messages"] = chat_history
+
+    print(f"openai_format: {openai_format}")
+
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        api_key = auth_header[len("Bearer ") :]
+    else:
+        raise HTTPException(
+            status_code=401, detail={"error": "Missing or invalid Authorization header"}
+        )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            LITELLM_CHAT,
+            json=openai_format,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+        print(f"response: {response}")
+
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail={"error": f"Error from LiteLLM endpoint: {response.text}"},
+            )
+
+        openai_response = response.json()
+        print(f"openai_response: {openai_response}")
+        bedrock_response = await convert_openai_to_bedrock(openai_response)
+        print(f"bedrock_response: {bedrock_response}")
+
+    # Append assistant's response to history
+    assistant_message = openai_response["choices"][0]["message"]
+    print(f"assistant_message: {assistant_message}")
+    chat_history.append({"role": "assistant", "content": assistant_message["content"]})
+    update_chat_history(session_id, chat_history)
+    print(f"chat_history: {chat_history}")
+
+    bedrock_response["session_id"] = session_id
+    return bedrock_response, session_id
 
 
-def validate_prompt_variables(template_text: str, variables: Dict[str, Any]):
-    # Find all placeholders of the form {{variableName}}
-    found_placeholders = re.findall(r"{{\s*(\w+)\s*}}", template_text)
-    placeholders_set = set(found_placeholders)
-    variables_set = set(variables.keys())
+async def process_streaming_chat_request(
+    model_id: str, request: Request
+) -> (AsyncGenerator, str, List[Dict[str, str]], List[str]):
+    body = await request.json()
 
-    # Check if sets match exactly
-    if placeholders_set != variables_set:
-        # Sets differ, raise a 400 error
-        detail_message = {
-            "message": f"Prompt variable mismatch. Template placeholders: {placeholders_set}. Provided variables: {variables_set}."
-        }
-        raise HTTPException(status_code=400, detail=detail_message)
+    session_id = body.get("additionalModelRequestFields", {}).get("session-id", None)
+    print(f"session_id: {session_id}")
+    if session_id is not None:
+        chat_history = get_chat_history(session_id)
+        if chat_history is None:
+            chat_history = []
+            create_chat_history(session_id, chat_history)
+    else:
+        session_id = str(uuid.uuid4())
+        chat_history = []
+        create_chat_history(session_id, chat_history)
+
+    print(f"chat_history: {chat_history}")
+
+    openai_params = await convert_bedrock_to_openai(model_id, body, True)
+    print(f"openai_params: {openai_params}")
+
+    # Append the user message to chat_history
+    user_messages_this_round = [
+        m for m in openai_params["messages"] if m["role"] == "user"
+    ]
+    if user_messages_this_round:
+        chat_history.append(user_messages_this_round[-1])
+    print(f"chat_history: {chat_history}")
+
+    # Pass the entire chat_history to the LLM
+    openai_params["messages"] = chat_history
+    print(f"openai_params: {openai_params}")
+
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        api_key = auth_header[len("Bearer ") :]
+    else:
+        raise HTTPException(
+            status_code=401, detail={"error": "Missing or invalid Authorization header"}
+        )
+
+    client = AsyncOpenAI(api_key=api_key, base_url=LITELLM_ENDPOINT)
+    stream = await client.chat.completions.create(**openai_params)
+
+    assistant_content_parts = []
+
+    async def stream_wrapper():
+        message_started = False
+        content_block_index = 0
+        async for chunk in stream:
+            delta = chunk.choices[0].delta
+            finish_reason = chunk.choices[0].finish_reason
+
+            if delta.role and not message_started:
+                event_payload = json.dumps({"role": delta.role}).encode("utf-8")
+                yield create_event_message(event_payload, "messageStart")
+                message_started = True
+
+            if delta.content:
+                assistant_content_parts.append(delta.content)
+                event_payload = json.dumps(
+                    {
+                        "contentBlockIndex": content_block_index,
+                        "delta": {"text": delta.content},
+                    }
+                ).encode("utf-8")
+                yield create_event_message(event_payload, "contentBlockDelta")
+
+            if finish_reason == "stop":
+                event_payload = json.dumps({"stopReason": "end_turn"}).encode("utf-8")
+                yield create_event_message(event_payload, "messageStop")
+
+    return stream_wrapper(), session_id, chat_history, assistant_content_parts
 
 
-def construct_prompt_text_from_variables(template_text: str, variables: dict) -> str:
-    # variables is something like {"topic": {"text": "stuff"}}
-    # template_text is something like: "This is my first text prompt. Please summarize on {{topic}}."
-    # Replace {{topic}} with "stuff"
-    for var_name, var_value in variables.items():
-        value = var_value.get("text", "")
-        template_text = template_text.replace(f"{{{{{var_name}}}}}", value)
-    return template_text
+async def finalize_streaming_chat_history(
+    session_id: str,
+    chat_history: List[Dict[str, str]],
+    assistant_content_parts: List[str],
+):
+    assistant_message = {
+        "role": "assistant",
+        "content": "".join(assistant_content_parts),
+    }
+    chat_history.append(assistant_message)
+    update_chat_history(session_id, chat_history)
 
 
-# For some reason, fastapi takes escaped forward slashes (%2F) as being regular forward slashes, so needed to add a new route
-@app.post("/bedrock/model/{prompt_arn_prefix}/{prompt_id}/converse")
-async def handle_bedrock_request_prompts(
+@app.post("/bedrock/model/{prompt_arn_prefix}/{prompt_id}/converse-stream")
+async def handle_bedrock_streaming_request_prompts(
     prompt_arn_prefix: str, prompt_id: str, request: Request
 ):
-    print(f"prompt_arn_prefix: {prompt_arn_prefix}")
-    print(f"prompt_id: {prompt_id}")
     full_arn = prompt_arn_prefix + "/" + prompt_id
-    print(f"full_arn: {full_arn}")
-    result = await handle_bedrock_request(full_arn, request)
-    return result
+    return await handle_bedrock_streaming_request(full_arn, request)
 
 
-@app.post("/bedrock/model/{model_id}/converse")
-async def handle_bedrock_request(model_id: str, request: Request):
-    """Handle Bedrock Converse API requests."""
-    print("reached converse api")
+@app.post("/bedrock/model/{model_id}/converse-stream")
+async def handle_bedrock_streaming_request(model_id: str, request: Request):
     try:
-        body = await request.json()
+        stream_wrapper, session_id, chat_history, assistant_content_parts = (
+            await process_streaming_chat_request(model_id, request)
+        )
 
-        openai_format = await convert_bedrock_to_openai(model_id, body, False)
-
-        auth_header = request.headers.get("Authorization")
-        headers = {"Content-Type": "application/json"}
-        if auth_header:
-            headers["Authorization"] = auth_header
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                LITELLM_CHAT,
-                json=openai_format,
-                headers=headers,
-                timeout=30.0,
+        async def finalizing_stream():
+            async for event in stream_wrapper:
+                yield event
+            await finalize_streaming_chat_history(
+                session_id, chat_history, assistant_content_parts
             )
 
-            if response.status_code != 200:
-                return JSONResponse(
-                    status_code=response.status_code,
-                    content={"error": f"Error from LiteLLM endpoint: {response.text}"},
-                )
-
-            bedrock_response = await convert_openai_to_bedrock(response.json())
-            print(
-                f"converse api success returning bedrock_response: {bedrock_response}"
-            )
-            return JSONResponse(content=bedrock_response)
-
+        response = StreamingResponse(
+            finalizing_stream(), media_type="application/vnd.amazon.eventstream"
+        )
+        response.headers["X-Session-Id"] = session_id
+        return response
     except HTTPException as he:
-        print(f"HTTPException: {he} detail: {he.detail}")
         return JSONResponse(
             status_code=400,
             content=he.detail,
         )
     except Exception as e:
-        print(f"converse api errror e: {e}")
+        return JSONResponse(status_code=500, content=f"Internal server error: {str(e)}")
+
+
+@app.post("/bedrock/model/{prompt_arn_prefix}/{prompt_id}/converse")
+async def handle_bedrock_request_prompts(
+    prompt_arn_prefix: str, prompt_id: str, request: Request
+):
+    full_arn = prompt_arn_prefix + "/" + prompt_id
+    return await handle_bedrock_request(full_arn, request)
+
+
+@app.post("/bedrock/model/{model_id}/converse")
+async def handle_bedrock_request(model_id: str, request: Request):
+    try:
+        bedrock_response, session_id = await process_chat_request(model_id, request)
+        return JSONResponse(
+            content=bedrock_response, headers={"X-Session-Id": session_id}
+        )
+    except HTTPException as he:
+        print(f"exception: {he}")
+        return JSONResponse(
+            status_code=400,
+            content=he.detail,
+        )
+    except Exception as e:
+        print(f"exception: {e}")
         return JSONResponse(status_code=500, content=f"Internal server error: {str(e)}")
 
 

--- a/middleware/requirements.txt
+++ b/middleware/requirements.txt
@@ -6,3 +6,5 @@ openai
 botocore
 google-crc32c
 boto3
+sqlalchemy
+psycopg2-binary


### PR DESCRIPTION
Add support for chat history for the bedrock interface (synchronous and streaming)

In the response headers, `x-session-id` is now returned.

If you pass in that session id like this `additionalModelRequestFields={"session-id": session_id}`, it will keep track of the history of your past `user` and `assistant` messages, and you only need to pass in your latest `user` message

This info is stored in a new postgres database

Updated `test-middleware-synchronous.py` and `test-middleware-streaming.py` scripts with example of using new session id

**Related ToDos:**

- Add chat history for openAI interface
- Add Bedrock Managed Prompt support for openAI interface 

(these two will require having the main openAI interface go through the middleware)

- Expose endpoint where you can retrieve chat history for a `session-id` (feature needed to display history on a UI when you only have the session-id)
(This will require storing a hash of the api key or user id along with the chat history to ensure only the owner of the history can get the history. Will also add this check when passing in a session-id to the chat endpoints

- Expose endpoint where you can retrieve all session ids for a user (feature needed to display all of user's chats on a UI when you only have the user's api key)
(This will require storing a map of an api key hash / user-id to a list of session ids)