### PR TITLE
remove anyscale provider because it's broken on latest litellm versio…

### DIFF
--- a/config/default-config.yaml
+++ b/config/default-config.yaml
@@ -309,27 +309,6 @@ model_list:
     litellm_params:
       model: cohere/command-nightly
 
-  #AnyScale Models
-  - model_name: meta-llama/Llama-2-7b-chat-hf
-    litellm_params:
-      model: anyscale/meta-llama/Llama-2-7b-chat-hf
-
-  - model_name: meta-llama/Llama-2-13b-chat-hf
-    litellm_params:
-      model: anyscale/meta-llama/Llama-2-13b-chat-hf
-  
-  - model_name: meta-llama/Llama-2-70b-chat-hf
-    litellm_params:
-      model: anyscale/meta-llama/Llama-2-70b-chat-hf
-  
-  - model_name: mistralai/Mistral-7B-Instruct-v0.1
-    litellm_params:
-      model: anyscale/mistralai/Mistral-7B-Instruct-v0.1
-  
-  - model_name: codellama/CodeLlama-34b-Instruct-hf
-    litellm_params:
-      model: anyscale/codellama/CodeLlama-34b-Instruct-hf
-
   #Huggingface Models 
   #(Follow the below pattern to support any Huggingface serverless model you want to use from this list: https://huggingface.co/models?inference=warm&pipeline_tag=text-generation) 
   #(For custom models, text classification models, or dedicated inference endpoints, refer to the docs: https://docs.litellm.ai/docs/providers/huggingface)

--- a/litellm-cdk/bin/litellm-cdk.ts
+++ b/litellm-cdk/bin/litellm-cdk.ts
@@ -28,7 +28,6 @@ const codestralApiKey = String(app.node.tryGetContext("codestralApiKey"));
 const mistralApiKey = String(app.node.tryGetContext("mistralApiKey"));
 const azureAiApiKey = String(app.node.tryGetContext("azureAiApiKey"));
 
-const anyscaleApiKey = String(app.node.tryGetContext("anyscaleApiKey"));
 const nvidiaNimApiKey = String(app.node.tryGetContext("nvidiaNimApiKey"));
 const xaiApiKey = String(app.node.tryGetContext("xaiApiKey"));
 const perplexityaiApiKey = String(app.node.tryGetContext("perplexityaiApiKey"));
@@ -59,7 +58,6 @@ new LitellmCdkStack(app, 'LitellmCdkStack', {
   codestralApiKey: codestralApiKey,
   mistralApiKey: mistralApiKey,
   azureAiApiKey: azureAiApiKey,
-  anyscaleApiKey: anyscaleApiKey,
   nvidiaNimApiKey: nvidiaNimApiKey,
   xaiApiKey: xaiApiKey,
   perplexityaiApiKey: perplexityaiApiKey,

--- a/litellm-cdk/lib/litellm-cdk-stack.ts
+++ b/litellm-cdk/lib/litellm-cdk-stack.ts
@@ -41,7 +41,6 @@ interface LiteLLMStackProps extends cdk.StackProps {
   codestralApiKey: string;
   mistralApiKey: string;
   azureAiApiKey: string;
-  anyscaleApiKey: string;
   nvidiaNimApiKey: string;
   xaiApiKey: string;
   perplexityaiApiKey: string;
@@ -197,7 +196,6 @@ export class LitellmCdkStack extends cdk.Stack {
           CODESTRAL_API_KEY: props.codestralApiKey,
           MISTRAL_API_KEY: props.mistralApiKey,
           AZURE_AI_API_KEY: props.azureAiApiKey,
-          ANYSCALE_API_KEY: props.anyscaleApiKey,
           NVIDIA_NIM_API_KEY: props.nvidiaNimApiKey,
           XAI_API_KEY: props.xaiApiKey,
           PERPLEXITYAI_API_KEY: props.perplexityaiApiKey,
@@ -309,7 +307,6 @@ export class LitellmCdkStack extends cdk.Stack {
         CODESTRAL_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'CODESTRAL_API_KEY'),
         MISTRAL_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'MISTRAL_API_KEY'),
         AZURE_AI_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'AZURE_AI_API_KEY'),
-        ANYSCALE_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'ANYSCALE_API_KEY'),
         NVIDIA_NIM_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'NVIDIA_NIM_API_KEY'),
         XAI_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'XAI_API_KEY'),
         PERPLEXITYAI_API_KEY: ecs.Secret.fromSecretsManager(litellmOtherSecrets, 'PERPLEXITYAI_API_KEY'),


### PR DESCRIPTION
remove anyscale provider because it's broken on latest litellm versions and is not very popular
