### PR TITLE
Security scan fixes

### DIFF
--- a/config/default-config.yaml
+++ b/config/default-config.yaml
@@ -18,49 +18,82 @@ model_list:
     #tpm: 100000 #Set tokens per minute. Will stop sending traffic to this model once exceeded, and will send traffic to fallback models if configured.
     #rpm: 10000 #Set requests per minute. Will stop sending traffic to this model once exceeded, and will send traffic to fallback models if configured.
     litellm_params:
-      model: bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0
+      model: bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0
       #temperature: 0.7 # 👈 pass in default provider specific parameters like this
       #top_k: 1 # 👈 pass in default provider specific parameters like this
       #aws_region_name: us-west-2 #Override default of using the region litellm is deployed in
       # weight: 1 #Used to load balance between two different models. Give two different models the same "model_name" and the traffic will be distributed based on the relative weights
+  - model_name: us.anthropic.claude-3-5-sonnet-20240620-v1:0
+    litellm_params:
+      model: bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0
 
   - model_name: anthropic.claude-3-5-sonnet-20241022-v2:0
+    litellm_params:
+      model: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
+  - model_name: us.anthropic.claude-3-5-sonnet-20241022-v2:0
     litellm_params:
       model: bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0
 
   - model_name: anthropic.claude-3-5-haiku-20241022-v1:0
     litellm_params:
+      model: bedrock/anthropic.claude-3-5-haiku-20241022-v1:0
+  - model_name: us.anthropic.claude-3-5-haiku-20241022-v1:0
+    litellm_params:
       model: bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0
 
   - model_name: anthropic.claude-3-sonnet-20240229-v1:0
+    litellm_params:
+      model: bedrock/anthropic.claude-3-sonnet-20240229-v1:0
+  - model_name: us.anthropic.claude-3-sonnet-20240229-v1:0
     litellm_params:
       model: bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0
   
   - model_name: anthropic.claude-3-haiku-20240307-v1:0
     litellm_params:
+      model: bedrock/anthropic.claude-3-haiku-20240307-v1:0
+  - model_name: us.anthropic.claude-3-haiku-20240307-v1:0
+    litellm_params:
       model: bedrock/us.anthropic.claude-3-haiku-20240307-v1:0
   
   - model_name: anthropic.claude-3-opus-20240229-v1:0
+    litellm_params:
+      model: bedrock/anthropic.claude-3-opus-20240229-v1:0
+  - model_name: us.anthropic.claude-3-opus-20240229-v1:0
     litellm_params:
       model: bedrock/us.anthropic.claude-3-opus-20240229-v1:0
   
   - model_name: meta.llama3-1-405b-instruct-v1:0
     litellm_params:
+      model: bedrock/meta.llama3-1-405b-instruct-v1:0
+  - model_name: us.meta.llama3-1-405b-instruct-v1:0
+    litellm_params:
       model: bedrock/us.meta.llama3-1-405b-instruct-v1:0
   
   - model_name: meta.llama3-1-70b-instruct-v1:0
+    litellm_params:
+      model: bedrock/meta.llama3-1-70b-instruct-v1:0
+  - model_name: us.meta.llama3-1-70b-instruct-v1:0
     litellm_params:
       model: bedrock/us.meta.llama3-1-70b-instruct-v1:0
 
   - model_name: meta.llama3-1-8b-instruct-v1:0
     litellm_params:
+      model: bedrock/meta.llama3-1-8b-instruct-v1:0
+  - model_name: us.meta.llama3-1-8b-instruct-v1:0
+    litellm_params:
       model: bedrock/us.meta.llama3-1-8b-instruct-v1:0
   
   - model_name: meta.llama3-70b-instruct-v1:0
     litellm_params:
+      model: bedrock/meta.llama3-70b-instruct-v1:0
+  - model_name: us.meta.llama3-70b-instruct-v1:0
+    litellm_params:
       model: bedrock/us.meta.llama3-70b-instruct-v1:0
   
   - model_name: meta.llama3-8b-instruct-v1:0
+    litellm_params:
+      model: bedrock/meta.llama3-8b-instruct-v1:0
+  - model_name: us.meta.llama3-8b-instruct-v1:0
     litellm_params:
       model: bedrock/us.meta.llama3-8b-instruct-v1:0
 
@@ -74,13 +107,22 @@ model_list:
 
   - model_name: amazon.nova-pro-v1
     litellm_params:
+      model: bedrock/amazon.nova-pro-v1:0
+  - model_name: us.amazon.nova-pro-v1
+    litellm_params:
       model: bedrock/us.amazon.nova-pro-v1:0
 
   - model_name: amazon.nova-lite-v1
     litellm_params:
+      model: bedrock/amazon.nova-lite-v1:0
+  - model_name: us.amazon.nova-lite-v1
+    litellm_params:
       model: bedrock/us.amazon.nova-lite-v1:0
 
   - model_name: amazon.nova-micro-v1
+    litellm_params:
+      model: bedrock/amazon.nova-micro-v1:0
+  - model_name: us.amazon.nova-micro-v1
     litellm_params:
       model: bedrock/us.amazon.nova-micro-v1:0
 

--- a/litellm-s3-log-bucket-terraform/s3.tf
+++ b/litellm-s3-log-bucket-terraform/s3.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "log_bucket" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
 
   rule {
@@ -13,7 +13,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption
   }
 }
 
-resource "aws_s3_bucket_policy" "bucket_ssl_policy" {
+resource "aws_s3_bucket_policy" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.id
 
   policy = jsonencode({
@@ -36,4 +36,10 @@ resource "aws_s3_bucket_policy" "bucket_ssl_policy" {
       }
     ]
   })
+}
+
+resource "aws_s3_bucket_public_access_block" "log_bucket" {
+  bucket = aws_s3_bucket.log_bucket.id
+  block_public_acls   = true
+  block_public_policy = true
 }

--- a/litellm-terraform-stack/modules/base/ecr.tf
+++ b/litellm-terraform-stack/modules/base/ecr.tf
@@ -1,6 +1,10 @@
 resource "aws_ecr_repository" "my_ecr_repository" {
   count        = (var.disable_outbound_network_access && var.deployment_platform == "EKS") ? 1 : 0
   name         = "my-public-ecr-cache-repo"
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
   force_delete = true  # replicates cdk.RemovalPolicy.DESTROY
 }
 

--- a/litellm-terraform-stack/modules/base/iam.tf
+++ b/litellm-terraform-stack/modules/base/iam.tf
@@ -21,3 +21,27 @@ resource "aws_iam_role_policy_attachment" "vpc_flow_logs_attach" {
   role       = aws_iam_role.vpc_flow_logs_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
 }
+
+# First, create an IAM role for RDS Enhanced Monitoring
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name = "${var.name}-rds-enhanced-monitoring"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach the required policy for Enhanced Monitoring
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}

--- a/litellm-terraform-stack/modules/base/network.tf
+++ b/litellm-terraform-stack/modules/base/network.tf
@@ -101,7 +101,7 @@ data "aws_availability_zones" "available" {
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   count             = local.creating_new_vpc ? 1 : 0
   name              = "/aws/vpc/${var.name}-flow-logs"
-  retention_in_days = 30
+  retention_in_days = 365
 }
 
 resource "aws_flow_log" "this" {

--- a/litellm-terraform-stack/modules/base/network.tf
+++ b/litellm-terraform-stack/modules/base/network.tf
@@ -100,7 +100,7 @@ data "aws_availability_zones" "available" {
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   count             = local.creating_new_vpc ? 1 : 0
-  name              = "/aws/vpc/${var.name}-flow-logs"
+  name_prefix              = "/aws/vpc/${var.name}-flow-logs"
   retention_in_days = 365
 }
 

--- a/litellm-terraform-stack/modules/base/outputs.tf
+++ b/litellm-terraform-stack/modules/base/outputs.tf
@@ -124,9 +124,9 @@ output "database_url" {
 }
 
 output "litellm_master_key" {
-  value = random_password.litellm_master.result
+  value = local.litellm_master_key
 }
 
 output "litellm_salt_key" {
-  value = random_password.litellm_salt.result
+  value = local.litellm_salt_key
 }

--- a/litellm-terraform-stack/modules/base/rds.tf
+++ b/litellm-terraform-stack/modules/base/rds.tf
@@ -48,6 +48,24 @@ resource "aws_db_subnet_group" "main" {
   subnet_ids = local.chosen_subnet_ids
 }
 
+resource "aws_db_parameter_group" "example_pg" {
+  name   = "rds-postgres-parameter-group"
+  # Update the family to match your PostgreSQL version
+  family = "postgres15"
+
+  # Enable logging of all statements
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
+
+  # Log statements that take longer than 1ms
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "1"
+  }
+}
+
 # Database #1: litellm
 resource "aws_db_instance" "database" {
   identifier                = "${var.name}-litellm-db"
@@ -66,7 +84,9 @@ resource "aws_db_instance" "database" {
   deletion_protection       = false
   multi_az = true
   performance_insights_enabled = true
-  enabled_cloudwatch_logs_exports = ["general", "error", "slowquery"]
+  enabled_cloudwatch_logs_exports = ["general", "error", "slowquery", "postgresql"]
   auto_minor_version_upgrade = true
   monitoring_interval = 60
+  parameter_group_name = aws_db_parameter_group.example_pg.name
+  copy_tags_to_snapshot     = true
 }

--- a/litellm-terraform-stack/modules/base/rds.tf
+++ b/litellm-terraform-stack/modules/base/rds.tf
@@ -84,9 +84,10 @@ resource "aws_db_instance" "database" {
   deletion_protection       = false
   multi_az = true
   performance_insights_enabled = true
-  enabled_cloudwatch_logs_exports = ["general", "error", "slowquery", "postgresql"]
+  enabled_cloudwatch_logs_exports = ["postgresql"]
   auto_minor_version_upgrade = true
   monitoring_interval = 60
+  monitoring_role_arn      = aws_iam_role.rds_enhanced_monitoring.arn
   parameter_group_name = aws_db_parameter_group.example_pg.name
   copy_tags_to_snapshot     = true
 }

--- a/litellm-terraform-stack/modules/base/rds.tf
+++ b/litellm-terraform-stack/modules/base/rds.tf
@@ -30,6 +30,7 @@ resource "aws_security_group" "db_sg" {
   vpc_id      = local.final_vpc_id
 
   egress {
+    description = "allow all outbound access"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
@@ -64,4 +65,8 @@ resource "aws_db_instance" "database" {
   skip_final_snapshot       = true
   deletion_protection       = false
   multi_az = true
+  performance_insights_enabled = true
+  enabled_cloudwatch_logs_exports = ["general", "error", "slowquery"]
+  auto_minor_version_upgrade = true
+  monitoring_interval = 60
 }

--- a/litellm-terraform-stack/modules/base/redis.tf
+++ b/litellm-terraform-stack/modules/base/redis.tf
@@ -8,6 +8,7 @@ resource "aws_security_group" "redis_sg" {
   vpc_id      = local.final_vpc_id
 
   egress {
+    description = "allow all outbound access"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"

--- a/litellm-terraform-stack/modules/base/route53.tf
+++ b/litellm-terraform-stack/modules/base/route53.tf
@@ -5,22 +5,49 @@ data "aws_route53_zone" "public_zone" {
   private_zone = false
 }
 
+locals {
+  create_private_load_balancer = var.publicLoadBalancer ? false : local.creating_new_vpc || var.create_private_hosted_zone_in_existing_vpc ? true : false
+  import_private_load_balancer = var.publicLoadBalancer ? false : local.creating_new_vpc || var.create_private_hosted_zone_in_existing_vpc ? false : true
+}
+
 resource "aws_route53_zone" "new_private_zone" {
   //If public load balancer, never create private zone
   //If private load balancer, always create private zone if we are creating new vpc
   //If private load balancer, and user brings their own vpc, decide whether to create or import private hosted zone based on "var.create_private_hosted_zone_in_existing_vpc" variable
-  count = var.publicLoadBalancer ? 0 : local.creating_new_vpc || var.create_private_hosted_zone_in_existing_vpc ? 1 : 0
+  count = local.create_private_load_balancer ? 1 : 0
   name = var.hostedZoneName
   vpc {
     vpc_id = local.final_vpc_id
   }
 }
 
+
+
 data "aws_route53_zone" "existing_private_zone" {
   //If public load balancer, never create private zone
   //If private load balancer, always create private zone if we are creating new vpc
   //If private load balancer, and user brings their own vpc, decide whether to create or import private hosted zone based on "var.create_private_hosted_zone_in_existing_vpc" variable
-  count = var.publicLoadBalancer ? 0 : local.creating_new_vpc || var.create_private_hosted_zone_in_existing_vpc ? 0 : 1
+  count = local.import_private_load_balancer ? 1 : 0
   name = var.hostedZoneName
   private_zone = true
+}
+
+resource "aws_cloudwatch_log_group" "new_private_zone_query_logs" {
+  count = local.create_private_load_balancer ? 1 : 0
+
+  name              = "${var.hostedZoneName}-query-logs"
+  retention_in_days = 365
+}
+
+resource "aws_route53_query_logging_config" "new_private_zone_query_logging" {
+  # Create the query logging config only if the zone is actually created
+  count = local.create_private_load_balancer ? 1 : 0
+
+  zone_id                   = aws_route53_zone.new_private_zone[0].zone_id
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.new_private_zone_query_logs[0].arn
+
+  # Helps avoid "no zone_id" errors by ensuring the zone is created first
+  depends_on = [
+    aws_route53_zone.new_private_zone
+  ]
 }

--- a/litellm-terraform-stack/modules/base/route53.tf
+++ b/litellm-terraform-stack/modules/base/route53.tf
@@ -21,8 +21,6 @@ resource "aws_route53_zone" "new_private_zone" {
   }
 }
 
-
-
 data "aws_route53_zone" "existing_private_zone" {
   //If public load balancer, never create private zone
   //If private load balancer, always create private zone if we are creating new vpc
@@ -30,24 +28,4 @@ data "aws_route53_zone" "existing_private_zone" {
   count = local.import_private_load_balancer ? 1 : 0
   name = var.hostedZoneName
   private_zone = true
-}
-
-resource "aws_cloudwatch_log_group" "new_private_zone_query_logs" {
-  count = local.create_private_load_balancer ? 1 : 0
-
-  name              = "${var.hostedZoneName}-query-logs"
-  retention_in_days = 365
-}
-
-resource "aws_route53_query_logging_config" "new_private_zone_query_logging" {
-  # Create the query logging config only if the zone is actually created
-  count = local.create_private_load_balancer ? 1 : 0
-
-  zone_id                   = aws_route53_zone.new_private_zone[0].zone_id
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.new_private_zone_query_logs[0].arn
-
-  # Helps avoid "no zone_id" errors by ensuring the zone is created first
-  depends_on = [
-    aws_route53_zone.new_private_zone
-  ]
 }

--- a/litellm-terraform-stack/modules/base/s3.tf
+++ b/litellm-terraform-stack/modules/base/s3.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "config_bucket" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "config_bucket" {
   bucket = aws_s3_bucket.config_bucket.id
 
   rule {
@@ -16,7 +16,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
     }
 }
 
-resource "aws_s3_bucket_policy" "config_ssl_policy" {
+resource "aws_s3_bucket_policy" "config_bucket" {
   bucket = aws_s3_bucket.config_bucket.id
 
   policy = jsonencode({
@@ -39,6 +39,12 @@ resource "aws_s3_bucket_policy" "config_ssl_policy" {
       }
     ]
   })
+}
+
+resource "aws_s3_bucket_public_access_block" "config_bucket" {
+  bucket = aws_s3_bucket.config_bucket.id
+  block_public_acls   = true
+  block_public_policy = true
 }
 
 # Single file upload of `config.yaml`

--- a/litellm-terraform-stack/modules/base/secrets-manager.tf
+++ b/litellm-terraform-stack/modules/base/secrets-manager.tf
@@ -19,13 +19,18 @@ resource "aws_secretsmanager_secret" "litellm_master_salt" {
   recovery_window_in_days = 0
 }
 
+locals {
+  litellm_master_key = "sk-${random_password.litellm_master.result}"
+  litellm_salt_key = "sk-${random_password.litellm_salt.result}"
+}
+
 # Store the generated values
 resource "aws_secretsmanager_secret_version" "litellm_master_salt_ver" {
   secret_id = aws_secretsmanager_secret.litellm_master_salt.id
 
   secret_string = jsonencode({
-    LITELLM_MASTER_KEY = "sk-${random_password.litellm_master.result}"
-    LITELLM_SALT_KEY   = "sk-${random_password.litellm_salt.result}"
+    LITELLM_MASTER_KEY = local.litellm_master_key
+    LITELLM_SALT_KEY   = local.litellm_salt_key
   })
 }
 

--- a/litellm-terraform-stack/modules/base/vpc-endpoints.tf
+++ b/litellm-terraform-stack/modules/base/vpc-endpoints.tf
@@ -6,12 +6,15 @@ resource "aws_security_group" "vpc_endpoints_sg" {
   description       = "Security group for Interface VPC Endpoints"
   vpc_id            = local.final_vpc_id
   ingress {
+    description = "allow inbound access from within the vpc"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [cidrsubnet("0.0.0.0/0", 0, 0)] # or limit to local.final_vpc_id's CIDR if you prefer
+    cidr_blocks = [local.creating_new_vpc ? aws_vpc.new[0].cidr_block : data.aws_vpc.existing[0].cidr_block]
+    //cidr_blocks = [cidrsubnet("0.0.0.0/0", 0, 0)] # or limit to local.final_vpc_id's CIDR if you prefer
   }
   egress {
+    description = "allow all outbound access"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"

--- a/litellm-terraform-stack/modules/base/vpc-endpoints.tf
+++ b/litellm-terraform-stack/modules/base/vpc-endpoints.tf
@@ -11,7 +11,6 @@ resource "aws_security_group" "vpc_endpoints_sg" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = [local.creating_new_vpc ? aws_vpc.new[0].cidr_block : data.aws_vpc.existing[0].cidr_block]
-    //cidr_blocks = [cidrsubnet("0.0.0.0/0", 0, 0)] # or limit to local.final_vpc_id's CIDR if you prefer
   }
   egress {
     description = "allow all outbound access"

--- a/litellm-terraform-stack/modules/base/waf.tf
+++ b/litellm-terraform-stack/modules/base/waf.tf
@@ -56,4 +56,26 @@ resource "aws_wafv2_web_acl" "litellm_waf" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "LiteLLMCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
 }

--- a/litellm-terraform-stack/modules/ecs/alb.tf
+++ b/litellm-terraform-stack/modules/ecs/alb.tf
@@ -10,6 +10,12 @@ resource "aws_lb" "this" {
   security_groups    = [aws_security_group.alb_sg.id]
   internal           = var.public_load_balancer ? false : true
   idle_timeout       = 60
+  drop_invalid_header_fields = true
+  access_logs {
+    bucket  = aws_s3_bucket.access_log_bucket.bucket
+    prefix  = "alb-access-logs-"
+    enabled = true
+   }
 }
 
 # HTTPS Listener

--- a/litellm-terraform-stack/modules/ecs/cloudwatch.tf
+++ b/litellm-terraform-stack/modules/ecs/cloudwatch.tf
@@ -1,9 +1,9 @@
 resource "aws_cloudwatch_log_group" "litellm" {
   name              = "/ecs/${var.name}-litellm"
-  retention_in_days = 30  # Adjust retention period as needed
+  retention_in_days = 365
 }
 
 resource "aws_cloudwatch_log_group" "middleware" {
   name              = "/ecs/${var.name}-middleware"
-  retention_in_days = 30  # Adjust retention period as needed
+  retention_in_days = 365
 }

--- a/litellm-terraform-stack/modules/ecs/s3.tf
+++ b/litellm-terraform-stack/modules/ecs/s3.tf
@@ -1,0 +1,39 @@
+resource "aws_s3_bucket" "access_log_bucket" {
+  bucket_prefix = "access-logs-"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "access_log_bucket" {
+  bucket = aws_s3_bucket.access_log_bucket.id
+
+  rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+}
+
+resource "aws_s3_bucket_policy" "access_log_bucket" {
+  bucket = aws_s3_bucket.access_log_bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnforceSSLOnly"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.access_log_bucket.arn,
+          "${aws_s3_bucket.access_log_bucket.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/litellm-terraform-stack/modules/ecs/s3.tf
+++ b/litellm-terraform-stack/modules/ecs/s3.tf
@@ -37,3 +37,9 @@ resource "aws_s3_bucket_policy" "access_log_bucket" {
     ]
   })
 }
+
+resource "aws_s3_bucket_public_access_block" "access_log_bucket" {
+  bucket = aws_s3_bucket.access_log_bucket.id
+  block_public_acls   = true
+  block_public_policy = true
+}

--- a/litellm-terraform-stack/modules/eks/eks.tf
+++ b/litellm-terraform-stack/modules/eks/eks.tf
@@ -74,6 +74,7 @@ resource "aws_security_group_rule" "db_ingress" {
   protocol          = "tcp"
   cidr_blocks       = [data.aws_vpc.existing.cidr_block]
   security_group_id = data.aws_security_group.db.id
+  description              = "Allow EKS tasks to connect to RDS"
 }
 
 # Add ingress rules to Redis security group
@@ -84,6 +85,7 @@ resource "aws_security_group_rule" "redis_ingress" {
   protocol          = "tcp"
   cidr_blocks       = [data.aws_vpc.existing.cidr_block]
   security_group_id = data.aws_security_group.redis.id
+  description              = "Allow EKS tasks to connect to Redis"
 }
 
 resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {

--- a/litellm-terraform-stack/modules/eks/eks.tf
+++ b/litellm-terraform-stack/modules/eks/eks.tf
@@ -126,6 +126,13 @@ resource "aws_eks_cluster" "this" {
   version  = var.cluster_version
   role_arn = aws_iam_role.eks_cluster[0].arn
 
+  encryption_config {
+    provider {
+      key_arn = aws_kms_key.eks_secrets[0].arn
+    }
+    resources = ["secrets"]
+  }
+
   vpc_config {
     subnet_ids              = concat(data.aws_subnets.private.ids, data.aws_subnets.public.ids)
     endpoint_private_access = true
@@ -143,7 +150,8 @@ resource "aws_eks_cluster" "this" {
   # If your cluster IAM role or its policies are managed elsewhere,
   # you can add explicit depends_on to ensure they exist first:
   depends_on = [
-    aws_iam_role_policy_attachment.eks_cluster_policy
+    aws_iam_role_policy_attachment.eks_cluster_policy,
+    aws_iam_role_policy.eks_cluster_kms_policy
   ]
 }
 

--- a/litellm-terraform-stack/modules/eks/eks.tf
+++ b/litellm-terraform-stack/modules/eks/eks.tf
@@ -128,13 +128,6 @@ resource "aws_eks_cluster" "this" {
   version  = var.cluster_version
   role_arn = aws_iam_role.eks_cluster[0].arn
 
-  encryption_config {
-    provider {
-      key_arn = aws_kms_key.eks_secrets[0].arn
-    }
-    resources = ["secrets"]
-  }
-
   vpc_config {
     subnet_ids              = concat(data.aws_subnets.private.ids, data.aws_subnets.public.ids)
     endpoint_private_access = true
@@ -153,7 +146,6 @@ resource "aws_eks_cluster" "this" {
   # you can add explicit depends_on to ensure they exist first:
   depends_on = [
     aws_iam_role_policy_attachment.eks_cluster_policy,
-    aws_iam_role_policy.eks_cluster_kms_policy
   ]
 }
 

--- a/litellm-terraform-stack/modules/eks/eks.tf
+++ b/litellm-terraform-stack/modules/eks/eks.tf
@@ -128,6 +128,13 @@ resource "aws_eks_cluster" "this" {
   version  = var.cluster_version
   role_arn = aws_iam_role.eks_cluster[0].arn
 
+  encryption_config {
+    provider {
+      key_arn = aws_kms_key.eks_secrets[0].arn
+    }
+    resources = ["secrets"]
+  }
+
   vpc_config {
     subnet_ids              = concat(data.aws_subnets.private.ids, data.aws_subnets.public.ids)
     endpoint_private_access = true
@@ -146,6 +153,7 @@ resource "aws_eks_cluster" "this" {
   # you can add explicit depends_on to ensure they exist first:
   depends_on = [
     aws_iam_role_policy_attachment.eks_cluster_policy,
+    aws_iam_role_policy.eks_cluster_kms_policy
   ]
 }
 

--- a/litellm-terraform-stack/modules/eks/iam.tf
+++ b/litellm-terraform-stack/modules/eks/iam.tf
@@ -140,8 +140,6 @@ data "aws_iam_policy_document" "pod_identity_assume_role" {
   }
 }
 
-
-
 resource "aws_iam_role" "cw_observability_role" {
   # Make sure this only creates if you're creating the cluster or adding add-ons
   count = var.create_cluster || var.install_add_ons_in_existing_eks_cluster ? 1 : 0
@@ -155,4 +153,30 @@ resource "aws_iam_role_policy_attachment" "cw_agent_policy_attach" {
 
   role       = aws_iam_role.cw_observability_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+data "aws_iam_policy_document" "eks_cluster_kms" {
+  statement {
+    sid     = "AllowKMSUseOfEncryptionKey"
+    effect  = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+      "kms:CreateGrant"
+    ]
+    resources = [
+      aws_kms_key.eks_secrets[0].arn
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "eks_cluster_kms_policy" {
+  count = var.create_cluster ? 1 : 0
+  name = "EKS-Cluster-KMS-Policy"
+  role = aws_iam_role.eks_cluster[0].name
+
+  policy = data.aws_iam_policy_document.eks_cluster_kms.json
 }

--- a/litellm-terraform-stack/modules/eks/iam.tf
+++ b/litellm-terraform-stack/modules/eks/iam.tf
@@ -128,29 +128,3 @@ resource "aws_iam_role_policy" "node_additional_policies" {
     ]
   })
 }
-
-data "aws_iam_policy_document" "eks_cluster_kms" {
-  statement {
-    sid     = "AllowKMSUseOfEncryptionKey"
-    effect  = "Allow"
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-      "kms:CreateGrant"
-    ]
-    resources = [
-      aws_kms_key.eks_secrets[0].arn
-    ]
-  }
-}
-
-resource "aws_iam_role_policy" "eks_cluster_kms_policy" {
-  count = var.create_cluster ? 1 : 0
-  name = "EKS-Cluster-KMS-Policy"
-  role = aws_iam_role.eks_cluster[0].name
-
-  policy = data.aws_iam_policy_document.eks_cluster_kms.json
-}

--- a/litellm-terraform-stack/modules/eks/iam.tf
+++ b/litellm-terraform-stack/modules/eks/iam.tf
@@ -128,3 +128,29 @@ resource "aws_iam_role_policy" "node_additional_policies" {
     ]
   })
 }
+
+data "aws_iam_policy_document" "eks_cluster_kms" {
+  statement {
+    sid     = "AllowKMSUseOfEncryptionKey"
+    effect  = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+      "kms:CreateGrant"
+    ]
+    resources = [
+      aws_kms_key.eks_secrets[0].arn
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "eks_cluster_kms_policy" {
+  count = var.create_cluster ? 1 : 0
+  name = "EKS-Cluster-KMS-Policy"
+  role = aws_iam_role.eks_cluster[0].name
+
+  policy = data.aws_iam_policy_document.eks_cluster_kms.json
+}

--- a/litellm-terraform-stack/modules/eks/kms.tf
+++ b/litellm-terraform-stack/modules/eks/kms.tf
@@ -1,0 +1,41 @@
+resource "aws_kms_key" "eks_secrets" {
+count = var.create_cluster ? 1 : 0
+  description             = "KMS key for encrypting EKS Secrets"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  # Key policy that allows:
+  # - Root to do anything (standard practice)
+  # - The EKS cluster role to use the key for encryption (kms:Encrypt, kms:Decrypt, etc.)
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-default-1"
+    Statement = [
+      {
+        Sid      = "Enable IAM User Permissions"
+        Effect   = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow use of the key by EKS Cluster Role"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.eks_cluster[0].arn
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+          "kms:CreateGrant"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/litellm-terraform-stack/modules/eks/main.tf
+++ b/litellm-terraform-stack/modules/eks/main.tf
@@ -97,6 +97,7 @@ resource "kubernetes_deployment" "litellm" {
         container {
           name  = "litellm-container"
           image = "${var.ecr_litellm_repository_url}:${var.litellm_version}"
+          image_pull_policy = "Always"
 
           port {
             container_port = 4000
@@ -438,6 +439,7 @@ resource "kubernetes_service" "litellm" {
 # Add AWS Load Balancer Controller
 module "aws_load_balancer_controller_irsa_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.52.2"
 
   role_name                              = "${var.name}-aws-load-balancer-controller"
   attach_load_balancer_controller_policy = true

--- a/litellm-terraform-stack/providers.tf
+++ b/litellm-terraform-stack/providers.tf
@@ -17,48 +17,23 @@ provider "aws" {
   }
 }
 
+
+
+data "aws_eks_cluster_auth" "cluster" {
+  count = local.platform == "EKS" ? 1 : 0
+  name = module.eks_cluster[0].cluster_name
+}
+
 provider "kubernetes" {
   host                   = local.platform == "EKS" ? module.eks_cluster[0].cluster_endpoint : ""
   cluster_ca_certificate = local.platform == "EKS" ? base64decode(module.eks_cluster[0].cluster_ca) : ""
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    args        = local.platform == "EKS" ? ["eks", "get-token", "--cluster-name", module.eks_cluster[0].cluster_name] : []
-  }
+  token = local.platform == "EKS" ? data.aws_eks_cluster_auth.cluster[0].token : ""
 }
 
 provider "helm" {
   kubernetes {
     host                   = local.platform == "EKS" ? module.eks_cluster[0].cluster_endpoint : ""
     cluster_ca_certificate = local.platform == "EKS" ? base64decode(module.eks_cluster[0].cluster_ca) : ""
-    exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "aws"
-      args        = local.platform == "EKS" ? ["eks", "get-token", "--cluster-name", module.eks_cluster[0].cluster_name] : []
-    }
+    token = local.platform == "EKS" ? data.aws_eks_cluster_auth.cluster[0].token : ""
   }
 }
-
-
-
-# provider "kubernetes" {
-#   host                   = module.eks_cluster[0].cluster_endpoint
-#   cluster_ca_certificate = base64decode(module.eks_cluster[0].cluster_ca)
-#   exec {
-#     api_version = "client.authentication.k8s.io/v1beta1"
-#     command     = "aws"
-#     args        = ["eks", "get-token", "--cluster-name", module.eks_cluster[0].cluster_name]
-#   }
-# }
-
-# provider "helm" {
-#   kubernetes {
-#     host                   = module.eks_cluster[0].cluster_endpoint
-#     cluster_ca_certificate = base64decode(module.eks_cluster[0].cluster_ca)
-#     exec {
-#       api_version = "client.authentication.k8s.io/v1beta1"
-#       command     = "aws"
-#       args        = ["eks", "get-token", "--cluster-name", module.eks_cluster[0].cluster_name]
-#     }
-#   }
-# }


### PR DESCRIPTION
- unabstract inference profiles. Make it an explicit option to use the inference profile or to not
- block public access to S3 buckets
- scan docker images on push
- make log retention 1 year
- fix bug around master key in secrets manager not matching EKS secret
- add descriptions to all security groups and security group rules
- enable performance insights on rds
- enable cloudwatch log exports on rds
- enable auto minor version upgrade on rds
- enable rds enhanced monitoring, every 60 minutes
- copy rds tags to rds database snapshots
- refactor to make conditional logic easier to read
- restrict vpc endpoint access to only within the vpc cidr
- add new waf rule `AWSManagedRulesKnownBadInputsRuleSet`
- add access logs to application load balancer
- add kms encryption to eks secrets
- add cloudwatch observability add on to new eks clusters
- for "kubernetes_deployment", set "image_pull_policy" to "Always"
- Fix bug where EKS credentials were cached in kubernetes and helm terraform providers, making the cluster unaccessible after 15 minutes when the cached credentials expired. Now always fetch fresh credentials