### PR TITLE
add delay for RBAC permission propagation

### DIFF
--- a/litellm-terraform-stack/modules/eks/main.tf
+++ b/litellm-terraform-stack/modules/eks/main.tf
@@ -10,6 +10,15 @@ locals {
 }
 
 # Kubernetes Secrets
+# Add a sleep to allow RBAC permissions to propagate
+resource "time_sleep" "wait_for_rbac_propagation_before_creating_secrets" {
+  depends_on = [
+    aws_eks_access_entry.admin,
+    aws_eks_access_policy_association.admin_policy
+  ]
+  create_duration = "5s"
+}
+
 resource "kubernetes_secret" "litellm_api_keys" {
   metadata {
     name = "litellm-api-keys"
@@ -44,8 +53,7 @@ resource "kubernetes_secret" "litellm_api_keys" {
   }
 
   depends_on = [
-    aws_eks_access_entry.admin,
-    aws_eks_access_policy_association.admin_policy,
+    time_sleep.wait_for_rbac_propagation_before_creating_secrets,
     aws_eks_access_entry.developers,
     aws_eks_access_entry.operators
   ]
@@ -62,8 +70,7 @@ resource "kubernetes_secret" "middleware_secrets" {
   }
 
   depends_on = [
-    aws_eks_access_entry.admin,
-    aws_eks_access_policy_association.admin_policy,
+    time_sleep.wait_for_rbac_propagation_before_creating_secrets,
     aws_eks_access_entry.developers,
     aws_eks_access_entry.operators
   ]

--- a/litellm-terraform-stack/modules/eks/versions.tf
+++ b/litellm-terraform-stack/modules/eks/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.13.0"
+    }
   }
 }


### PR DESCRIPTION
*Description of changes:* Added a 5 second delay between RBAC policy association and secret creation to ensure permissions are fully propagated in the EKS cluster. This prevents potential race conditions where Kubernetes secrets creation fails if created before RBAC permissions are active.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
