### PR TITLE
fix ecs listener rules preventing bedrock endpoints from being reached

### DIFF
--- a/litellm-terraform-stack/modules/ecs/alb.tf
+++ b/litellm-terraform-stack/modules/ecs/alb.tf
@@ -444,26 +444,6 @@ resource "aws_lb_listener_rule" "health_check_exception_http" {
   }
 }
 
-# CloudFront authentication rule for HTTP
-resource "aws_lb_listener_rule" "cloudfront_auth_http" {
-  count        = var.use_cloudfront ? 1 : 0
-  listener_arn = aws_lb_listener.http.arn
-  priority     = 5  # Second priority, after health checks
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.tg_4000.arn
-  }
-
-  # Check for the CloudFront secret header
-  condition {
-    http_header {
-      http_header_name = "X-CloudFront-Secret"
-      values           = ["litellm-cf-${random_password.cloudfront_secret[0].result}"]
-    }
-  }
-}
-
 # Duplicate all path-specific rules for the HTTP listener with header authentication
 
 # bedrock model for HTTP


### PR DESCRIPTION
# Fix CloudFront to Bedrock Endpoint Access Issue

## Issue

When CloudFront was enabled, the ALB listener rule with priority 5 (CloudFront authentication rule) was preventing traffic from reaching the Bedrock endpoints. This rule was checking for a specific CloudFront secret header before allowing traffic to pass through, but this was causing issues with the Bedrock endpoint access pattern.

## Changes Made

- Modified the ALB listener rules configuration to ensure proper traffic routing from CloudFront to Bedrock endpoints
- Removed the priority 5 authentication rule that was blocking legitimate traffic from CloudFront to Bedrock model endpoints
- Ensured that all path-specific endpoint rules (priorities 8-16) can now properly receive traffic when routed through CloudFront

## Testing Done

- Verified that CloudFront can now properly route requests to Bedrock endpoints
- Confirmed that the security posture remains intact through other validation mechanisms
- Tested end-to-end request flow from CloudFront to Bedrock services

## Security Considerations

The removal of this rule doesn't compromise security as:

1. The CloudFront distribution itself provides an authentication layer
2. The ALB is still protected by other security measures (WAF, security groups, etc.)
3. Path-specific rules for HTTP traffic still validate the CloudFront secret header
