### PR TITLE
chore: bump Postgres and LiteLLM versions

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # LITELLM_VERSION eg: main-v1.56.5
 # Get it from https://github.com/berriai/litellm/pkgs/container/litellm/versions?filters%5Bversion_type%5D=tagged
-LITELLM_VERSION="litellm_stable_release_branch-v1.73.0-stable"
+LITELLM_VERSION="litellm_stable_release_branch-v1.76.1-stable"
 TERRAFORM_S3_BUCKET_NAME="" #Must be globally unique
 BUILD_FROM_SOURCE="false"
 HOSTED_ZONE_NAME=""

--- a/litellm-terraform-stack/modules/base/rds.tf
+++ b/litellm-terraform-stack/modules/base/rds.tf
@@ -51,7 +51,7 @@ resource "aws_db_subnet_group" "main" {
 resource "aws_db_parameter_group" "example_pg" {
   name   = "rds-postgres-parameter-group"
   # Update the family to match your PostgreSQL version
-  family = "postgres15"
+  family = "postgres17"
 
   # Enable logging of all statements
   parameter {
@@ -70,7 +70,7 @@ resource "aws_db_parameter_group" "example_pg" {
 resource "aws_db_instance" "database" {
   identifier                = "${var.name}-litellm-db"
   engine                    = "postgres"
-  engine_version           = "15" # or "15.x"
+  engine_version           = "17" # (Should be compatible back to at least "15.x" if needed)
   instance_class            = var.rds_instance_class
   storage_type              = "gp3"
   allocated_storage         = var.rds_allocated_storage


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Small version bumps to help keep the solution current:
- Bumped `.env.template`'s listed LiteLLM version from 1.73-stable to 1.76-stable
- Bumped RDS Postgres from v15 to v17

Deployment and core functionality seems to work fine for me with these upgrades - not sure if there are any specific plan of tests we should be carrying out to verify?

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
