### PR TITLE
Fix hardcoded VPC ID in delete-fake-llm-load-testing-server.sh

### DIFF
--- a/delete-fake-llm-load-testing-server.sh
+++ b/delete-fake-llm-load-testing-server.sh
@@ -46,7 +46,7 @@ echo $ARCH
 
 echo "about to destroy"
 
-export TF_VAR_vpc_id="vpc-02b681fa786fa8292"
+export TF_VAR_vpc_id=$VPC_ID
 export TF_VAR_ecr_fake_server_repository=$APP_NAME
 export TF_VAR_architecture=$ARCH
 export TF_VAR_fake_llm_load_testing_endpoint_certifiacte_arn=$FAKE_LLM_LOAD_TESTING_ENDPOINT_CERTIFICATE_ARN


### PR DESCRIPTION
## Summary

- `delete-fake-llm-load-testing-server.sh` had a hardcoded VPC ID instead of using the `$VPC_ID` variable
- `$VPC_ID` is already retrieved correctly from `terraform output -raw vpc_id` earlier in the same script
- This bug would cause the destroy to target the wrong VPC for any user other than the original author