### PR TITLE
Fix EKS deployment for Scenario 1 (Public with CloudFront, no custom domain)

### DIFF
--- a/litellm-terraform-stack/modules/eks/main.tf
+++ b/litellm-terraform-stack/modules/eks/main.tf
@@ -279,15 +279,19 @@ resource "kubernetes_ingress_v1" "litellm" {
   wait_for_load_balancer = true
   metadata {
     name = "litellm-ingress"
-    annotations = {
-      "kubernetes.io/ingress.class"                = "alb"
-      "alb.ingress.kubernetes.io/scheme"           = var.public_load_balancer ? "internet-facing" : "internal"
-      "alb.ingress.kubernetes.io/target-type"      = "ip"
-      "alb.ingress.kubernetes.io/listen-ports"     = jsonencode([{"HTTP" = 80}, {"HTTPS" = 443}])
-      "alb.ingress.kubernetes.io/certificate-arn"  = var.certificate_arn
-      "alb.ingress.kubernetes.io/ssl-policy"       = "ELBSecurityPolicy-2016-08"
-      "alb.ingress.kubernetes.io/wafv2-acl-arn"   = var.wafv2_acl_arn
-    }
+    annotations = merge(
+      {
+        "kubernetes.io/ingress.class"            = "alb"
+        "alb.ingress.kubernetes.io/scheme"       = var.public_load_balancer ? "internet-facing" : "internal"
+        "alb.ingress.kubernetes.io/target-type"  = "ip"
+        "alb.ingress.kubernetes.io/listen-ports" = var.certificate_arn != "" ? jsonencode([{"HTTP" = 80}, {"HTTPS" = 443}]) : jsonencode([{"HTTP" = 80}])
+        "alb.ingress.kubernetes.io/wafv2-acl-arn" = var.wafv2_acl_arn
+      },
+      var.certificate_arn != "" ? {
+        "alb.ingress.kubernetes.io/certificate-arn" = var.certificate_arn
+        "alb.ingress.kubernetes.io/ssl-policy"      = "ELBSecurityPolicy-2016-08"
+      } : {}
+    )
   }
 
   spec {

--- a/litellm-terraform-stack/modules/eks/outputs.tf
+++ b/litellm-terraform-stack/modules/eks/outputs.tf
@@ -51,7 +51,7 @@ output "private_subnet_ids" {
 
 output "litellm_url" {
   description = "The URL for the LiteLLM service"
-  value       = "https://${aws_route53_record.litellm.name}"
+  value       = var.hosted_zone_name != "" ? "https://${aws_route53_record.litellm[0].name}" : "https://${data.aws_lb.ingress_alb.dns_name}"
 }
 
 output "cluster_ca" {

--- a/litellm-terraform-stack/modules/eks/route53.tf
+++ b/litellm-terraform-stack/modules/eks/route53.tf
@@ -1,13 +1,16 @@
 
+# Only lookup the Route53 zone if hosted_zone_name is provided
 data "aws_route53_zone" "selected" {
-  name = var.hosted_zone_name
+  count        = var.hosted_zone_name != "" ? 1 : 0
+  name         = var.hosted_zone_name
   private_zone = var.public_load_balancer ? false : true
 }
 
 
-# Create the A record
+# Only create the A record if hosted_zone_name is provided
 resource "aws_route53_record" "litellm" {
-  zone_id = data.aws_route53_zone.selected.zone_id
+  count   = var.hosted_zone_name != "" ? 1 : 0
+  zone_id = data.aws_route53_zone.selected[0].zone_id
   name    = var.record_name  # e.g., "litellm.mirodrr.people.aws.dev"
   type    = "A"
 

--- a/middleware/requirements.txt
+++ b/middleware/requirements.txt
@@ -9,5 +9,6 @@ boto3
 sqlalchemy
 psycopg2-binary
 okta-jwt-verifier
+requests
 cryptography
 anyio


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The EKS module fails during terraform apply when hosted_zone_name is left empty because route53.tf unconditionally looks up the hosted zone and creates an A record.

Changes:

- Added count conditionals to data.aws_route53_zone.selected and aws_route53_record.litellm so they are only created when hosted_zone_name != ""

- Updated litellm_url output to fall back to the ALB DNS name when no custom domain is configured

- Made ALB ingress HTTPS listener and certificate annotations conditional on certificate_arn being set (fixes "A certificate must be specified for HTTPS listeners" error in Scenario 1)

- Added requests to requirements.txt (missing transitive dependency of okta-jwt-verifier that causes the middleware container to crash on startup)

This allows the EKS deployment option to work without requiring a Route53 hosted zone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.