### PR TITLE
Remove Service Catalog AppRegistry

### DIFF
--- a/litellm-terraform-stack/providers.tf
+++ b/litellm-terraform-stack/providers.tf
@@ -30,19 +30,6 @@ provider "aws" {
   }
 }
 
-resource "aws_servicecatalogappregistry_application" "solution_application" {
-  name        = "${local.SolutionNameKeySatisfyingRestrictions}-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}"
-  description = "Service Catalog application to track and manage all your resources for the solution ${local.common_labels.SolutionNameKey}"
-
-  tags = {
-    "Solutions:SolutionID"      = local.common_labels.SolutionID
-    "Solutions:SolutionName"    = local.common_labels.SolutionNameKey
-    "Solutions:SolutionVersion" = local.common_labels.SolutionVersionKey
-    "Solutions:ApplicationType" = "AWS-Solutions"
-  }
-}
-
-
 
 data "aws_eks_cluster_auth" "cluster" {
   count = local.platform == "EKS" ? 1 : 0


### PR DESCRIPTION
*Issue #, if available:*

New customers are unable to deploy. Terraform rrror message as below

> 
> Error: creating AWS Service Catalog AppRegistry Application ("Guidance-for-Running-Generative-AI-Gateway-Proxy-on-AWS-ap-southeast-1-12345689012"): operation error Service Catalog AppRegistry: CreateApplication, https response error StatusCode: 403, RequestID: a80d3154-c8d1-4c9e-9c8e-7fee484a216e, api error AccessDeniedException: AWS Service Catalog AppRegistry is in maintenance mode and is no longer available to new customers as of July 30, 2026. For alternatives, learn more at https://docs.aws.amazon.com/servicecatalog/latest/arguide/app-registry-availability-change.html
> │ 
> │   with aws_servicecatalogappregistry_application.solution_application,
> │   on providers.tf line 33, in resource "aws_servicecatalogappregistry_application" "solution_application":
> │   33: resource "aws_servicecatalogappregistry_application" "solution_application" {
> │ 
> │ operation error Service Catalog AppRegistry: CreateApplication, https response error StatusCode: 403, RequestID: a80d3154-c8d1-4c9e-9c8e-7fee484a216e, api error AccessDeniedException: AWS Service Catalog
> │ AppRegistry is in maintenance mode and is no longer available to new customers as of July 30, 2026. For alternatives, learn more at
> │ https://docs.aws.amazon.com/servicecatalog/latest/arguide/app-registry-availability-change.html



*Description of changes:*

Remove `aws_servicecatalogappregistry_application` creation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
